### PR TITLE
docs: add Sequenzy email marketing skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Once you're comfortable with the basics, explore the full list below. Every reso
 - **[production]** [drawio-skill](https://github.com/Agents365-ai/drawio-skill) by [Agents365-ai](https://github.com/Agents365-ai) — Generates draw.io diagrams from natural language and exports to PNG/SVG/PDF. SKILL.md format, works across Claude Code, OpenClaw, Hermes, and Codex. 1.1k+ stars.
 - **[production]** [open-design](https://github.com/nexu-io/open-design) by [nexu-io](https://github.com/nexu-io) — Local-first, open-source design alternative with 31 composable skills over 129 design systems, plus image, video, and audio generation. Integrates with Hermes via ACP/JSON-RPC. 28k+ stars.
 - **[beta]** [master-skill](https://github.com/voidborne-d/master-skill) by [voidborne-d](https://github.com/voidborne-d) — Distills an entire industry domain into a portable skill folder through a 5-phase research and synthesis pipeline. Works across Hermes, Claude Code, OpenClaw, and Codex. Ships 9 industries at v1.4.
+- **[beta]** [sequenzy-email-marketing](https://github.com/Sequenzy/skills/tree/main/skills/sequenzy-email-marketing) by [Sequenzy](https://github.com/Sequenzy) - Agent skill for operating Sequenzy lifecycle email marketing and transactional email workflows: subscribers, segments, campaigns, sequences, templates, and stats.
 
 ### Plugins
 


### PR DESCRIPTION
    ## Summary
    - Adds the Sequenzy email marketing Agent Skill to the relevant skill/resource section.
    - Keeps the description neutral and aligned with nearby entries.

    ## Links
    - Skill source: https://github.com/Sequenzy/skills/tree/main/skills/sequenzy-email-marketing
- ClawHub: https://clawhub.ai/polnikale/sequenzy-email-marketing

    ## Verification
    - Reviewed the target README section and contribution format.
    - Verified the Sequenzy skill source is public.
    - Changed files: README.md

    Diff stat:
    ```
    README.md | 1 +
 1 file changed, 1 insertion(+)
    ```
