### PR TITLE
feat: add TWZRD Agent Intel — Solana agent trust scoring MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,8 @@ Once you're comfortable with the basics, explore the full list below. Every reso
 - **[beta]** [mercury](https://github.com/hxsteric/mercury) by [hxsteric](https://github.com/hxsteric) — Multi-chain blockchain cash flow analyzer with a WebGL dashboard. On-chain forensics and flow visualization.
 - **[experimental]** [hermes-research-agent](https://github.com/Aum08Desai/hermes-research-agent) by [Aum08Desai](https://github.com/Aum08Desai) — Autonomous LLM research agent. Handles literature review, hypothesis generation, and experiment design end-to-end.
 
+- **[production]** [TWZRD Agent Intel](https://intel.twzrd.xyz) — Trust scoring MCP for autonomous Solana agents. `score_agent(wallet)` and `preflight_check(wallet)` are free; `get_trust_receipt(wallet)` returns a signed trust receipt via x402 micropayment. Verifies agent wallet identity before high-value multi-agent operations. Config: `{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}`.
+
 <br>
 
 ## Forks & Derivatives


### PR DESCRIPTION
## What this adds

[TWZRD Agent Intel](https://intel.twzrd.xyz) — production trust scoring MCP for autonomous Solana agents.

Added to **Domain Applications** as a blockchain/agent identity tool for Hermes deployments.

## Why it fits

Hermes supports native MCP integration. TWZRD Agent Intel provides on-chain trust scoring for AI agents on Solana — directly useful when Hermes needs to verify another agent's wallet identity before delegating tasks, initiating x402 micropayments, or routing high-value operations in multi-agent pipelines.

## The tool

- **score_agent(wallet)** — trust score (0–1), reputation signals, behavioral flags. Free.
- **preflight_check(wallet)** — go/no-go verdict before agent interactions. Free.  
- **get_trust_receipt(wallet)** — signed trust receipt for audit trails. Paid via x402 (~$0.001 USDC).

**MCP config:**
```json
{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}
```

Streamable-HTTP, no API key required for free tools.